### PR TITLE
Add .gitattributes to specify line-ending style for certain files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
+# On Windows, some Git clients may normalize all text files' line-endings to
+# CRLF, which causes obscure errors when running shell scripts. That is why
+# at least *.spec and *.sh need to have LF line-endings always.
 *.spec	eol=lf
 *.sh	eol=lf


### PR DESCRIPTION
To avoid strange errors when using the git version on Windows, add a .gitattributes file to explicitly specify that *.spec and *.sh should always have LF line-ending style.
