### PR TITLE
Show a numpad for the TextFields, not the full keyboard.

### DIFF
--- a/src/qml/pages/SailCalc.qml
+++ b/src/qml/pages/SailCalc.qml
@@ -83,6 +83,8 @@ Page {
                         height: aLabel.height
                         text: "8"
                         validator: IntValidator {}
+                        // Show a numpad only, instead of a full keyboard
+                        inputMethodHints: Qt.ImhDigitsOnly
                     }
                 }
                 Row {
@@ -99,6 +101,8 @@ Page {
                         height: aLabel.height
                         text: "3"
                         validator: IntValidator {}
+                        // Show a numpad only, instead of a full keyboard
+                        inputMethodHints: Qt.ImhDigitsOnly
                     }
                 }
             }


### PR DESCRIPTION
Since the TextFields are used to enter digits only in this app, showing a numpad makes more sense than the full keyboard.

Admittedly, each additional line in the code is a step further from being a _minimal_ Helloworld application.
