### PR TITLE
Fix spelling of "subtract" also in abbreviated form

### DIFF
--- a/pages/SailCalc.qml
+++ b/pages/SailCalc.qml
@@ -14,7 +14,7 @@ Page {
     property alias _aText: a.text
     property alias _bText: b.text
     property alias _sumText: sumLabel.text
-    property alias _substrText: substrLabel.text
+    property alias _subtrText: subtrLabel.text
     property alias _subtractMenuAction: subtractMenuAction
 
     // To enable PullDownMenu, place our content in a SilicaFlickable
@@ -29,7 +29,7 @@ Page {
                 text: "Subtract!"
                 onClicked: {
                     console.log("subtractMenuAction clicked")
-                    substrLabel.text = "A-B = " + (parseInt(a.text) - parseInt(b.text))
+                    subtrLabel.text = "A-B = " + (parseInt(a.text) - parseInt(b.text))
                 }
 
             }
@@ -73,7 +73,7 @@ Page {
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             }
             Label {
-                id: substrLabel
+                id: subtrLabel
                 text: "A-B = ?"
             }
         }

--- a/src/qml/pages/SailCalc.qml
+++ b/src/qml/pages/SailCalc.qml
@@ -14,7 +14,7 @@ Page {
     property alias _aText: a.text
     property alias _bText: b.text
     property alias _sumText: sumLabel.text
-    property alias _substrText: substrLabel.text
+    property alias _subtrText: subtrLabel.text
     property alias _subtractMenuAction: subtractMenuAction
 
     // To enable PullDownMenu, place our content in a SilicaFlickable
@@ -29,7 +29,7 @@ Page {
                 text: "Subtract!"
                 onClicked: {
                     console.log("subtractMenuAction clicked")
-                    substrLabel.text = "A-B = " + (parseInt(a.text) - parseInt(b.text))
+                    subtrLabel.text = "A-B = " + (parseInt(a.text) - parseInt(b.text))
                 }
 
             }
@@ -112,7 +112,7 @@ Page {
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
             }
             Label {
-                id: substrLabel
+                id: subtrLabel
                 text: "A-B = ?"
             }
         }

--- a/tests/tst_NonUiTests.qml
+++ b/tests/tst_NonUiTests.qml
@@ -32,7 +32,7 @@ TestCase {
     }
 
     function test_subtractionAfterMenuAction() {
-        bigCalc._substrText = ""
+        bigCalc._subtrText = ""
         bigCalc._aText = "19"
         bigCalc._bText = "9"
 
@@ -41,7 +41,7 @@ TestCase {
 
         // click simulation via signals works just fine, however
         bigCalc._subtractMenuAction.clicked(null)
-        compare(bigCalc._substrText, "A-B = 10", "expected 19 - 9 to equal 10")
+        compare(bigCalc._subtrText, "A-B = 10", "expected 19 - 9 to equal 10")
     }
 }
 

--- a/tests/tst_RealUiTest.qml
+++ b/tests/tst_RealUiTest.qml
@@ -26,7 +26,7 @@ ApplicationWindow {
         when: windowShown
 
         function test_menuAction() {
-            bigCalc._substrText = ""
+            bigCalc._subtrText = ""
             bigCalc._aText = "19"
             bigCalc._bText = "9"
 
@@ -34,7 +34,7 @@ ApplicationWindow {
             // UI is actually created - that's why mouseClick works, but for some reason isn't rendered until after the test case methods
 
             bigCalc._subtractMenuAction.clicked(null)
-            compare(bigCalc._substrText, "A-B = 10", "expected 19 - 9 to equal 10")
+            compare(bigCalc._subtrText, "A-B = 10", "expected 19 - 9 to equal 10")
         }
     }
 


### PR DESCRIPTION
Fix spelling of "subtract"; the previous fix missed these few label names where it was used in an abbreviated form.
